### PR TITLE
Fix asymmetric clock noise by not regenerating random number

### DIFF
--- a/src/Kilobot.h
+++ b/src/Kilobot.h
@@ -105,7 +105,7 @@ private:
 			message_tx_success();
 		}
 		kilo_ticks++;
-		double tick_rand = uniform_rand_real(0, 1);
+		const double tick_rand = uniform_rand_real(0, 1);
 		if (tick_rand < 0.1)
 		{
 			if (tick_rand < 0.05)


### PR DESCRIPTION
Probably simple fix to #48